### PR TITLE
feat: Implement Windows-specific tray icon handling

### DIFF
--- a/electron/iconFromPNG.js
+++ b/electron/iconFromPNG.js
@@ -16,9 +16,18 @@ function loadPNGIcon(filename) {
     // For macOS, use createFromPath which handles PNG files properly
     const icon = nativeImage.createFromPath(iconPath);
     
-    // Mark as template for macOS (adapts to dark/light mode)
+    // Platform-specific icon handling
     if (process.platform === 'darwin') {
+      // Mark as template for macOS (adapts to dark/light mode)
       icon.setTemplateImage(true);
+    } else if (process.platform === 'win32') {
+      // Windows: Ensure icon is proper size (16x16 or 32x32 recommended for tray)
+      // Windows automatically scales, but we can resize if needed
+      const size = icon.getSize();
+      if (size.width > 32 || size.height > 32) {
+        // Resize large icons for better Windows tray display
+        return icon.resize({ width: 32, height: 32 });
+      }
     }
     
     console.log(`PNG icon loaded: size=${JSON.stringify(icon.getSize())}, empty=${icon.isEmpty()}`);
@@ -32,15 +41,23 @@ function loadPNGIcon(filename) {
 // Get icon for phase using PNG files
 function getIconForPhase(phase) {
   const phaseIconMap = {
-    // BadAss mode phases
+    // Queen mode phases (female perspective)
     'Bloody Hell Week': 'cloud-lightning.png',
     'Finally Got My Sh*t Together': 'sun.png',
     'Horny AF': 'cloud-sun.png',
     'Getting Real Tired of This BS': 'cloud.png',
-    'Pre-Chaos Mood Swings': 'cloud-rain-wind.png',  // Using rain-wind for mood swings
+    'Pre-Chaos Mood Swings': 'cloud-rain-wind.png',
     'Apocalypse Countdown': 'tornado.png',
     
-    // Professional mode phases (same icons as BadAss for consistency)
+    // King mode phases (partner perspective)
+    'Code Red Alert': 'cloud-lightning.png',
+    'Safe Zone Active': 'sun.png',
+    'High Energy Warning': 'cloud-sun.png',
+    'Patience Level: Low': 'cloud.png',
+    'Volatility Alert': 'cloud-rain-wind.png',
+    'DEFCON 1': 'tornado.png',
+    
+    // Legacy Professional mode phases (kept for compatibility)
     'Menstruation': 'cloud-lightning.png',
     'Follicular Phase': 'sun.png',
     'Ovulation': 'cloud-sun.png',

--- a/scripts/windows-icon-helper.js
+++ b/scripts/windows-icon-helper.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+console.log(`
+Windows Tray Icon Best Practices
+=================================
+
+1. Icon Sizes:
+   - System Tray: 16x16 or 32x32 pixels (PNG or ICO)
+   - High DPI: Provide 32x32 for better scaling
+   - Notification Area: 16x16 is standard
+
+2. Current Implementation:
+   - Using PNG files that work on both Windows and macOS
+   - Icons automatically resize to 32x32 if larger
+   - Context menu added for Windows right-click
+
+3. Windows-Specific Features Added:
+   ✅ Context menu with Show/Hide/Quit options
+   ✅ Window positioning above taskbar
+   ✅ Automatic icon resizing for tray
+   ✅ Support for both Queen and King mode icons
+
+4. Testing on Windows:
+   - Build: npm run build:win
+   - Test installer: dist/MoodBooMs-Setup-1.0.0.exe
+   - Test portable: dist/MoodBooMs-Portable-1.0.0.exe
+
+5. Icon Files Currently Used:
+`);
+
+// List current icon files
+const iconsDir = path.join(__dirname, '../electron/assets/icons');
+const iconFiles = fs.readdirSync(iconsDir).filter(f => f.endsWith('.png'));
+
+iconFiles.forEach(file => {
+  const filePath = path.join(iconsDir, file);
+  const stats = fs.statSync(filePath);
+  console.log(`   - ${file} (${stats.size} bytes)`);
+});
+
+console.log(`
+6. To Create Windows ICO (Optional):
+   - Use online converter: https://convertio.co/png-ico/
+   - Or ImageMagick: convert icon32.png icon.ico
+   - Place in electron/assets/icons/icon.ico
+
+Note: The app works fine with PNG icons on Windows.
+      ICO format is optional for native Windows feel.
+`);


### PR DESCRIPTION
## Summary
- Implemented comprehensive Windows tray icon support with platform-specific behaviors
- Added context menu for better UX on Windows (right-click menu)
- Improved cross-platform compatibility while maintaining native feel

## Changes
- **Context Menu**: Added system tray context menu with Show/Hide/About/Quit options
- **Window Positioning**: Platform-specific positioning (above taskbar on Windows, below menubar on macOS)
- **Icon Resizing**: Auto-resize large icons to 32x32 for optimal Windows tray display
- **Phase Support**: Updated icon mapping to include all Queen/King mode phase names
- **Documentation**: Added helper script with Windows tray icon best practices

## Technical Details
- Windows: Window appears above taskbar, right-click shows context menu
- macOS: Window appears below menubar icon, maintains existing behavior
- Icons automatically resize if larger than 32x32 on Windows
- Context menu works on both platforms for consistency

## Test Plan
- [x] Test tray icon appears correctly on macOS
- [x] Test context menu on macOS (right-click)
- [x] Test window positioning on macOS
- [ ] Test tray icon on Windows 10
- [ ] Test context menu on Windows
- [ ] Test window positioning above taskbar on Windows
- [ ] Test with different DPI settings

Closes #42